### PR TITLE
[docker] Add support for multiple build architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM java:8-jre-alpine
+ARG ARCH=amd64
 
-ENV BMP_VERSION="2.1.4" \
-    BMP_DOWNLOAD_SHA256="27c4080411adff919586e909c664c73bebb8ba8bfcaea259ce58327222e5e8fb"
-
+FROM java:8-jre-alpine AS dependencies-amd64
 RUN apk update \
     && apk add ca-certificates curl unzip tzdata \
     && update-ca-certificates
+
+FROM arm32v6/openjdk:8-jre-alpine AS dependencies-arm32v6
+RUN apk update \
+    && apk add ca-certificates curl unzip tzdata \
+    && update-ca-certificates
+
+FROM dependencies-${ARCH} as build
+ENV BMP_VERSION="2.1.4" \
+    BMP_DOWNLOAD_SHA256="27c4080411adff919586e909c664c73bebb8ba8bfcaea259ce58327222e5e8fb"
 
 RUN curl -fSL -o /tmp/browsermob-proxy.zip "https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-$BMP_VERSION/browsermob-proxy-$BMP_VERSION-bin.zip" \
 	&& echo "$BMP_DOWNLOAD_SHA256  /tmp/browsermob-proxy.zip" |  sha256sum -c - \


### PR DESCRIPTION
Hello @raul72 
This PR add's support for multiple build architectures using `build stages` and `build arguments`. This will not change the default container (because default arg is `amd64`) however it allows for building `arm32v6` images from this source code via

```
docker build -t "browsermob-proxy:local" --build-argument ARCH=arm32v6
```

Additional architectures could be added here but I did not do it.
The images can also be uploaded to the registry, however this requires some manual effort (Docker Hub does not support cross-architecture builds out of the box). If you have an OSX this is easy, otherwise skip it.
